### PR TITLE
Add --server argument to launch the server

### DIFF
--- a/scripts/development.sh
+++ b/scripts/development.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 rm -rf _public
-node_modules/.bin/brunch watch
+node_modules/.bin/brunch watch --server


### PR DESCRIPTION
The documentation states that one just need to run `./scripts/development.sh` and open browser to `http://localhost:3333`, but we need to pass --server argument to the `brunch watch` command to effectively launch the server.
